### PR TITLE
Only check for allowed values when we have them

### DIFF
--- a/src/pyload/config/parser.py
+++ b/src/pyload/config/parser.py
@@ -109,7 +109,7 @@ class ConfigOption(object):
 
     def set(self, value, store=True):
         norm_value = self._normalize_value(value)
-        if norm_value not in self.allowed_values:
+        if self.allowed_values and norm_value not in self.allowed_values:
             raise InvalidValueError(value)
         if self.value == norm_value:
             return None
@@ -344,7 +344,7 @@ class ConfigParser(ConfigSection):
         return config
 
     def _gen_fileconfig(self):
-        config = OrderedDict((self.SELF_SECTION, OrderedDict()))
+        config = OrderedDict({self.SELF_SECTION: OrderedDict()})
         for name, item in self.loweritems():
             if self.is_section(name):
                 fc = self._to_fileconfig(item, name)


### PR DESCRIPTION
This fixed an issue when `allowed_values` was empty. Instead of failing, consider this scenario to have no restrictions for the value to save.

Stacktrace:
```
Process Core-1:
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "build/bdist.linux-x86_64/egg/pyload/core/init.py", line 457, in run
    self._init_config()
  File "build/bdist.linux-x86_64/egg/pyload/core/init.py", line 327, in _init_config
    session = ConfigParser(self.__SESSIONFILENAME, session_defaults)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 170, in set
    item.set(arg, *args, **kwargs)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 170, in set
    item.set(arg, *args, **kwargs)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 113, in set
    raise InvalidValueError(value)
InvalidValueError: 1500734895.45
```

It also fixes an issue with an `OrderedDict` that was being incorrectly initialized.

Stacktrace:
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "build/bdist.linux-x86_64/egg/pyload/core/init.py", line 457, in run
    self._init_config()
  File "build/bdist.linux-x86_64/egg/pyload/core/init.py", line 327, in _init_config
    session = ConfigParser(self.__SESSIONFILENAME, session_defaults)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 170, in set
    item.set(arg, *args, **kwargs)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 170, in set
    item.set(arg, *args, **kwargs)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 118, in set
    self.__parser.store()
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 358, in store
    config = self._gen_fileconfig()
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 347, in _gen_fileconfig
    config = OrderedDict((self.SELF_SECTION, OrderedDict()))
  File "/usr/lib/python2.7/collections.py", line 69, in __init__
    self.__update(*args, **kwds)
  File "$HOME/.virtualenvs/pyload2/lib/python2.7/_abcoll.py", line 571, in update
    for key, value in other:
ValueError: need more than 0 values to unpack
```