### PR TITLE
Use parser slot in ConfigOption and ConfigSection

### DIFF
--- a/src/pyload/config/parser.py
+++ b/src/pyload/config/parser.py
@@ -60,7 +60,7 @@ class ConfigOption(object):
 
     def __init__(self, parser, value, label=None, desc=None,
                  allowed_values=None, input_type=None):
-        self.__parser = parser
+        self.parser = parser
 
         self.type = None
         self.value = None
@@ -115,7 +115,7 @@ class ConfigOption(object):
             return None
         self.value = norm_value
         if store:
-            self.__parser.store()
+            self.parser.store()
 
 
 class ConfigSection(InscDict):
@@ -130,7 +130,7 @@ class ConfigSection(InscDict):
         """
         Constructor.
         """
-        self.__parser = parser
+        self.parser = parser
         self.label = "" if label is None else str(label)
         self.desc = "" if desc is None else str(desc)
         self.update(config or ())
@@ -142,7 +142,7 @@ class ConfigSection(InscDict):
             entry_type = value[0]
             entry_args = value[1:]
             func = ConfigSection if entry_type == 'section' else ConfigOption
-            entry_obj = func(self.__parser, *entry_args)
+            entry_obj = func(self.parser, *entry_args)
         return entry_obj
 
     def reset(self):
@@ -197,10 +197,10 @@ class ConfigSection(InscDict):
             raise AlreadyExistsKeyError(name)
         if label is None:
             label = name.strip().capitalize()
-        section = ConfigSection(self.__parser, config, label, desc)
+        section = ConfigSection(self.parser, config, label, desc)
         self.__setitem__(name, section)
         if store or (store is None and config):
-            self.__parser.store()
+            self.parser.store()
         return section
 
     def add_option(self, name, value, label=None, desc=None,
@@ -210,10 +210,10 @@ class ConfigSection(InscDict):
         if label is None:
             label = name.strip().capitalize()
         option = ConfigOption(
-            self.__parser, value, label, desc, allowed_values, input_type)
+            self.parser, value, label, desc, allowed_values, input_type)
         self.__setitem__(name, option)
         if store:
-            self.__parser.store()
+            self.parser.store()
         return option
 
     def add(self, section, *args, **kwargs):


### PR DESCRIPTION
By using a private attribute `__parser` instead of the defined slot `parser`, the underlying MutableMapping was mapping the parser object, getting a maximum recursion depth error, because it was trying to expand not only the config sections and options, but also the parser itself, over and over again.

By using the provided `parser` slot, this no longer occurs.

Stacktrace:
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "build/bdist.linux-x86_64/egg/pyload/core/init.py", line 457, in run
    self._init_config()
  File "build/bdist.linux-x86_64/egg/pyload/core/init.py", line 327, in _init_config
    session = ConfigParser(self.__SESSIONFILENAME, session_defaults)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 170, in set
    item.set(arg, *args, **kwargs)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 170, in set
    item.set(arg, *args, **kwargs)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 118, in set
    self.__parser.store()
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 358, in store
    config = self._gen_fileconfig()
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 350, in _gen_fileconfig
    fc = self._to_fileconfig(item, name)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 339, in _to_fileconfig
    fc = self._to_fileconfig(item, sub_name)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 335, in _to_fileconfig
    for name, item in section.loweritems():
  File "build/bdist.linux-x86_64/egg/pyload/utils/struct/init.py", line 58, in <genexpr>
    for lowerkey, (key, val) in self.__dict__.items())
  File "build/bdist.linux-x86_64/egg/pyload/utils/struct/init.py", line 36, in <genexpr>
    return iter(key for key, val in self.__dict__.values())
  File "build/bdist.linux-x86_64/egg/pyload/utils/struct/init.py", line 36, in <genexpr>
    return iter(key for key, val in self.__dict__.values())
(...)
  File "build/bdist.linux-x86_64/egg/pyload/utils/struct/init.py", line 36, in <genexpr>
    return iter(key for key, val in self.__dict__.values())
RuntimeError: maximum recursion depth exceeded
```