### PR TITLE
Consider option's allowed_values always an iterable

### DIFF
--- a/src/pyload/config/parser.py
+++ b/src/pyload/config/parser.py
@@ -89,11 +89,11 @@ class ConfigOption(object):
         self.value = self.default = self._normalize_value(value)
 
     def _set_allowed(self, allowed):
-        if allowed:
-            values = [self._normalize_value(v) for v in allowed]
-            self.allowed_values = range(*values)
-        else:
+        if not allowed:
             self.allowed_values = ()
+            return
+
+        self.allowed_values = tuple(self._normalize_value(v) for v in allowed)
 
     def _normalize_value(self, value):
         return self._convert_map[self.type](value)


### PR DESCRIPTION
`self.allowed_values` was generating a `range` with the received values. However, that approach doesn't work for lists of string values, as the `language` option:
https://github.com/pyload/pyload/blob/454a8fcd9d44ffac14ab9630594c35647332c6b3/src/pyload/core/config/default.py#L51

Also, integer options that specify a list of allowed values are already defined with an iterable of possible values, so there's no need to use a `range` at this point:
* https://github.com/pyload/pyload/blob/454a8fcd9d44ffac14ab9630594c35647332c6b3/src/pyload/core/config/default.py#L61
* https://github.com/pyload/pyload/blob/454a8fcd9d44ffac14ab9630594c35647332c6b3/src/pyload/core/config/default.py#L63

Relevant stacktrace:
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "build/bdist.linux-x86_64/egg/pyload/core/init.py", line 461, in run
    self._init_config()
  File "build/bdist.linux-x86_64/egg/pyload/core/init.py", line 328, in _init_config
    session = ConfigParser(self.__SESSIONFILENAME, session_defaults)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 247, in __init__
    ConfigSection.__init__(self, self, config)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 140, in __init__
    self.update(config or ())
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 162, in update
    for name, value in iterable
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 149, in _to_configentry
    entry_obj = func(self.parser, *entry_args)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 140, in __init__
    self.update(config or ())
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 162, in update
    for name, value in iterable
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 149, in _to_configentry
    entry_obj = func(self.parser, *entry_args)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 74, in __init__
    self._set_allowed(allowed_values)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 98, in _set_allowed
    self.allowed_values = range(*values)
  File "$HOME/.virtualenvs/pyload2/local/lib/python2.7/site-packages/future/types/newrange.py", line 45, in __init__
    raise TypeError('range() requires 1-3 int arguments')
TypeError: range() requires 1-3 int arguments
```