### PR TITLE
Allow negative (unlimited) sizes in the parser

### DIFF
--- a/src/pyload/config/parser.py
+++ b/src/pyload/config/parser.py
@@ -48,7 +48,9 @@ class ConfigOption(object):
         InputType.Float: lambda x: 0.0 if x is None else float(x),
         InputType.Tristate: lambda x: x if x is None else bool(x),
         InputType.Octal: lambda x: 0 if x is None else oct(x),
-        InputType.Size: lambda x: 0 if x is None else parse.bytesize(x),
+        InputType.Size:
+            lambda x: 0 if x is None else (
+                -1 if str(x) == '-1' else parse.bytesize(x)),
         InputType.Address:
             lambda x: (None, None) if x is None else (
                 endpoint if isendpoint(x) else socket)(x),


### PR DESCRIPTION
Currently, `parse.bytesize` expects a string to convert to different units. However, it doesn't expect negative integers, e.g. used for unlimited speed.

Handling it here, as conceptually `bytesize` should not be called for negative numbers.

Related stacktrace:
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "build/bdist.linux-x86_64/egg/pyload/core/init.py", line 465, in run
    self._init_config()
  File "build/bdist.linux-x86_64/egg/pyload/core/init.py", line 344, in _init_config
    self.config = ConfigParser(self.__CONFIGFILENAME, config_defaults)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 243, in __init__
    ConfigSection.__init__(self, self, config)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 136, in __init__
    self.update(config or ())
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 158, in update
    for name, value in iterable
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 145, in _to_configentry
    entry_obj = func(self.parser, *entry_args)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 136, in __init__
    self.update(config or ())
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 158, in update
    for name, value in iterable
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 145, in _to_configentry
    entry_obj = func(self.parser, *entry_args)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 73, in __init__
    self._set_value(value)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 89, in _set_value
    self.value = self.default = self._normalize_value(value)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 99, in _normalize_value
    return self._convert_map[self.type](value)
  File "build/bdist.linux-x86_64/egg/pyload/config/parser.py", line 51, in <lambda>
    InputType.Size: lambda x: 0 if x is None else parse.bytesize(x),
  File "build/bdist.linux-x86_64/egg/pyload/utils/parse.py", line 114, in bytesize
    m = _RE_SIZE.match(text)
TypeError: expected string or buffer
```